### PR TITLE
Updated composer.json to support symfony 2.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "symfony/framework-bundle": "2.1.*",
+        "symfony/framework-bundle": ">=2.1,<3.0-dev",
         "doctrine/common": ">=2.3,<3.0",
         "jms/di-extra-bundle": ">=1.1,<2.0"
     },


### PR DESCRIPTION
It looks like there are no BC breaks in Symfony 2.2 affecting this bundle.
