### PR TITLE
Use DBAL object serialization mechanism

### DIFF
--- a/Console/Application.php
+++ b/Console/Application.php
@@ -82,7 +82,9 @@ class Application extends BaseApplication
             'id' => $jobId,
             'memoryUsage' => memory_get_peak_usage(),
             'memoryUsageReal' => memory_get_peak_usage(true),
-            'trace' => serialize($ex ? FlattenException::create($ex) : null),
+            'trace' => $ex ? FlattenException::create($ex) : null,
+        ), array(
+            'trace' => 'object',
         ));
     }
 


### PR DESCRIPTION
DBAL platform driver may need to specify special PDO::PARAM_\* binding for storing serialized object into database as "text" may not be able to store serialized PHP objects because they contain null characters (\0)
