### PR TITLE
Fixed database index definition

### DIFF
--- a/Entity/Job.php
+++ b/Entity/Job.php
@@ -28,7 +28,7 @@ use Symfony\Component\HttpKernel\Exception\FlattenException;
  * @ORM\Entity(repositoryClass = "JMS\JobQueueBundle\Entity\Repository\JobRepository")
  * @ORM\Table(name = "jms_jobs", indexes = {
  *     @ORM\Index(columns = {"command"}),
- *     @ORM\Index("job_runner", columns = {"executeAfter", "state"}),
+ *     @ORM\Index("job_runner", columns = {"execute_after", "state"}),
  * })
  * @ORM\ChangeTrackingPolicy("DEFERRED_EXPLICIT")
  *


### PR DESCRIPTION
When running doctrine console tools I get the following error:

  [Doctrine\DBAL\Schema\SchemaException]  
  There is no column with name 'executeAfter' on table 'jms_jobs'

This pull request fixes this error.
