### PR TITLE
Cloning a job

### DIFF
--- a/Entity/Job.php
+++ b/Entity/Job.php
@@ -192,6 +192,7 @@ class Job
         $this->runtime = null;
         $this->memoryUsage = null;
         $this->memoryUsageReal = null;
+        $this->relatedEntities = new ArrayCollection();
     }
 
     public function getId()


### PR DESCRIPTION
After cloning a job, relatedEntities was null instead of an ArrayCollection. Thus, I got an php error because foreach does not like null... 
