### PR TITLE
Optional attribute 'name' for a Job

### DIFF
--- a/Entity/Job.php
+++ b/Entity/Job.php
@@ -98,6 +98,9 @@ class Job
 
     /** @ORM\Column(type = "string") */
     private $command;
+    
+    /** @ORM\Column(type = "string", nullable = true) */
+    private $name;
 
     /** @ORM\Column(type = "json_array") */
     private $args;
@@ -293,6 +296,16 @@ class Job
     public function getCommand()
     {
         return $this->command;
+    }
+    
+    public function getName()
+    {
+        return $this->name;
+    }
+    
+    public function setName($name)
+    {
+        $this->name = $name;
     }
 
     public function getArgs()


### PR DESCRIPTION
I simply added an optional field to the Job entity in order to set it during the Job creation and display that pretty name to the user instead of the command attribute.
