### PR TITLE
Fixing a trailing s on the overview page

### DIFF
--- a/Resources/views/Job/macros.html.twig
+++ b/Resources/views/Job/macros.html.twig
@@ -35,5 +35,5 @@
 {%- endmacro %}
 
 {% macro queue(job) -%}
-        <span>{{ job.queue }} s</span>
+        <span>{{ job.queue }}</span>
 {%- endmacro %}


### PR DESCRIPTION
Just fixing a quick ui issue where there is a trailing s on the overview page.
