### PR TITLE
Delay between retries

### DIFF
--- a/Entity/Job.php
+++ b/Entity/Job.php
@@ -146,6 +146,9 @@ class Job
     /** @ORM\Column(type = "smallint", name="maxRetries", options = {"unsigned": true}) */
     private $maxRetries = 0;
 
+    /** @ORM\Column(type = "text", name="idleBetweenRetries") */
+    private $idleTimeBetweenRetries = '';
+
     /**
      * @ORM\ManyToOne(targetEntity = "Job", inversedBy = "retryJobs")
      * @ORM\JoinColumn(name="originalJob_id", referencedColumnName="id")
@@ -472,6 +475,16 @@ class Job
     public function setMaxRetries($tries)
     {
         $this->maxRetries = (integer) $tries;
+    }
+
+    public function setIdleTimeBetweenRetries($idleBetweenRetries)
+    {
+        $this->idleTimeBetweenRetries = $idleBetweenRetries;
+    }
+
+    public function getIdleTimeBetweenRetries()
+    {
+        return $this->idleTimeBetweenRetries;
     }
 
     public function isRetryAllowed()

--- a/Entity/Repository/JobRepository.php
+++ b/Entity/Repository/JobRepository.php
@@ -273,6 +273,7 @@ class JobRepository extends EntityRepository
                 if ($job->isRetryAllowed()) {
                     $retryJob = new Job($job->getCommand(), $job->getArgs());
                     $retryJob->setMaxRuntime($job->getMaxRuntime());
+                    $retryJob->setExecuteAfter(new \DateTime($job->getIdleTimeBetweenRetries()));
                     $job->addRetryJob($retryJob);
                     $this->_em->persist($retryJob);
                     $this->_em->persist($job);


### PR DESCRIPTION
Maybe this is a duplicate. In that case, of course just close.

It should be possible to set a time to wait for a job to retry. In some cases it doesn't make sense to immediate retry a job. For example 
- I have a job, to imports data from a remote resource. If the resource isn't reachable, it isn't probably reachable 1 second later.
- I have a job, that stresses the server quite much. In that case, when the job fails, I want to let the server cool down and other jobs can run without interruption, before I stress the server once more.
