### PR TITLE
Added the option to configure the PHP version to use when executing commands

### DIFF
--- a/Command/RunCommand.php
+++ b/Command/RunCommand.php
@@ -347,9 +347,9 @@ class RunCommand extends \Symfony\Bundle\FrameworkBundle\Command\ContainerAwareC
         if ( ! defined('PHP_WINDOWS_VERSION_MAJOR')) {
             $pb->add('exec');
         }
-
+ 
         $pb
-            ->add('php')
+            ->add($this->getContainer()->getParameter('jms_job_queue.php_path'))
             ->add($this->getContainer()->getParameter('kernel.root_dir').'/console')
             ->add('--env='.$this->env)
         ;

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -39,6 +39,7 @@ class Configuration implements ConfigurationInterface
 
         $rootNode
             ->children()
+                ->scalarNode("php_path")->defaultValue("php")->end()
                 ->booleanNode('statistics')->defaultTrue()->end();
 
         $defaultOptionsNode = $rootNode

--- a/DependencyInjection/JMSJobQueueExtension.php
+++ b/DependencyInjection/JMSJobQueueExtension.php
@@ -45,7 +45,8 @@ class JMSJobQueueExtension extends Extension
         if ($config['statistics']) {
             $loader->load('statistics.xml');
         }
-
+        
+        $container->setParameter("jms_job_queue.php_path", $config['php_path']);
         $container->setParameter('jms_job_queue.queue_options_defaults', $config['queue_options_defaults']);
         $container->setParameter('jms_job_queue.queue_options', $config['queue_options']);
     }

--- a/Resources/doc/installation.rst
+++ b/Resources/doc/installation.rst
@@ -147,6 +147,16 @@ A sample supervisord config might look like this:
 
 .. _supervisord: http://supervisord.org/
 
+
+PHP Path
+======================
+Sometimes it might be necessary to not use a PHP version found in your $PATH. To
+define which version you would like to use just specify it in your bundle's configuration
+
+.. code-block :: yml
+    jms_job_queue:
+        php_path: /path/to/php
+
 Queues
 ======================
 Mulitple queue support is enabled for 4 simultaneous job queues. 


### PR DESCRIPTION
In some environments it might be necessary to test or change the PHP version and it might be located in the server's $PATH. I added a configuration option to specify the path of the PHP version you would like to use. This config option defaults to using the server's path to maintain compatibility. 
