### PR TITLE
align composer branch alias with major version indicated by tags.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
     "target-dir": "JMS/JobQueueBundle",
     "extra": {
         "branch-alias": {
-            "dev-master": "0.1.x-dev"
+            "dev-master": "1.1.x-dev"
         }
     }
 }


### PR DESCRIPTION
The branch alias for dev-master is 0.1.x-dev, but the development on this branch has been released as versions 1.1.0 and 1.0.0. Should it be 1.1.x-dev instead?