### PR TITLE
Original job should be referenced on manual retry

### DIFF
--- a/Controller/JobController.php
+++ b/Controller/JobController.php
@@ -140,6 +140,7 @@ class JobController
         }
 
         $retryJob = clone $job;
+        $retryJob->setOriginalJob($job);
 
         $this->getEm()->persist($retryJob);
         $this->getEm()->flush();

--- a/Entity/Job.php
+++ b/Entity/Job.php
@@ -291,8 +291,16 @@ class Job
 
                 break;
 
-            case self::STATE_FINISHED:
             case self::STATE_FAILED:
+                if ( ! in_array($newState, array(self::STATE_FINISHED))) {
+                    throw new InvalidStateTransitionException($this, $newState, array(self::STATE_FINISHED));
+                }
+
+                $this->closedAt = new \DateTime();
+
+                break;
+
+            case self::STATE_FINISHED:
             case self::STATE_TERMINATED:
             case self::STATE_INCOMPLETE:
                 throw new InvalidStateTransitionException($this, $newState);

--- a/Tests/Entity/JobTest.php
+++ b/Tests/Entity/JobTest.php
@@ -91,6 +91,18 @@ class JobTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('finished', $job->getState());
     }
 
+    /**
+     * @depends testStateToRunning
+     */
+    public function testStateFailedToFinished(Job $job)
+    {
+        $job = clone $job;
+        $job->setState('running');
+        $job->setState('failed');
+        $job->setState('finished');
+        $this->assertEquals('finished', $job->getState());
+    }
+
     public function testAddOutput()
     {
         $job = new Job('foo');


### PR DESCRIPTION
Hitting the `Retry` button for a `failed` job will create a new job that does not reference the original. Even if the retry is successful, the failed job will remain in `failed` state at the top of the board.

The new job should reference the job that has failed previously. If the retry is successful, the original, failed job should reach state `finished`.
