### PR TITLE
Fix statistics for postgresql.

### DIFF
--- a/Controller/JobController.php
+++ b/Controller/JobController.php
@@ -84,8 +84,9 @@ class JobController
             $dataPerCharacteristic = array();
             foreach ($this->registry->getManagerForClass('JMSJobQueueBundle:Job')->getConnection()->query("SELECT * FROM jms_job_statistics WHERE job_id = ".$job->getId()) as $row) {
                 $dataPerCharacteristic[$row['characteristic']][] = array(
-                    $row['createdAt'],
-                    $row['charValue'],
+                    // hack because postgresql lower-cases all column names.
+                    array_key_exists('createdAt', $row) ? $row['createdAt'] : $row['createdat'],
+                    array_key_exists('charValue', $row) ? $row['charValue'] : $row['charvalue'],
                 );
             }
 


### PR DESCRIPTION
When using postgresql, all table columns are lower-cased, so the
hard-coded uses of `createdAt` and `charValue` don't work when fetching
the statistics of a job.

This hack fixes the problem, though it's far from being remotely
elegant.