### PR TITLE
Added restricted queues

### DIFF
--- a/Entity/Repository/JobRepository.php
+++ b/Entity/Repository/JobRepository.php
@@ -107,9 +107,9 @@ class JobRepository extends EntityRepository
         return $firstJob;
     }
 
-    public function findStartableJob(array &$excludedIds = array(), $excludedQueues = array())
+    public function findStartableJob(array &$excludedIds = array(), $excludedQueues = array(), $restrictedQueues = array())
     {
-        while (null !== $job = $this->findPendingJob($excludedIds, $excludedQueues)) {
+        while (null !== $job = $this->findPendingJob($excludedIds, $excludedQueues, $restrictedQueues)) {
             if ($job->isStartable()) {
                 return $job;
             }
@@ -186,7 +186,7 @@ class JobRepository extends EntityRepository
         return array($relClass, json_encode($relId));
     }
 
-    public function findPendingJob(array $excludedIds = array(), array $excludedQueues = array())
+    public function findPendingJob(array $excludedIds = array(), array $excludedQueues = array(), array $restrictedQueues = array())
     {
         $qb = $this->_em->createQueryBuilder();
         $qb->select('j')->from('JMSJobQueueBundle:Job', 'j')
@@ -210,6 +210,11 @@ class JobRepository extends EntityRepository
         if ( ! empty($excludedQueues)) {
             $conditions[] = $qb->expr()->notIn('j.queue', ':excludedQueues');
             $qb->setParameter('excludedQueues', $excludedQueues, Connection::PARAM_STR_ARRAY);
+        }
+
+        if ( ! empty($restrictedQueues)) {
+            $conditions[] = $qb->expr()->in('j.queue', ':restrictedQueues');
+            $qb->setParameter('restrictedQueues', $restrictedQueues, Connection::PARAM_STR_ARRAY);
         }
 
         $qb->where(call_user_func_array(array($qb->expr(), 'andX'), $conditions));
@@ -371,5 +376,20 @@ class JobRepository extends EntityRepository
             ->getOneOrNullResult();
 
         return count($result);
+    }
+
+    public function findRunningJobs($jobQueues = array())
+    {
+        $qb = $this->_em->createQueryBuilder()
+            ->select('j')
+            ->from('JMSJobQueueBundle:Job', 'j')
+            ->where('j.state = :state')
+            ->setParameter('state', Job::STATE_RUNNING);
+
+        if (!empty($jobQueues)) {
+            $qb->andWhere('j.queue IN (:queues)')->setParameter('queues', $jobQueues);
+        }
+
+        return $qb->getQuery()->getResult();
     }
 }

--- a/Tests/Functional/JobRepositoryTest.php
+++ b/Tests/Functional/JobRepositoryTest.php
@@ -66,6 +66,20 @@ class JobRepositoryTest extends BaseTestCase
         $this->assertNull($this->repo->findPendingJob(array($b->getId())));
     }
 
+    public function testFindPendingJobInRestrictedQueue()
+    {
+        $this->assertNull($this->repo->findPendingJob());
+
+        $a = new Job('a');
+        $b = new Job('b', array(), true, 'other_queue');
+        $this->em->persist($a);
+        $this->em->persist($b);
+        $this->em->flush();
+
+        $this->assertSame($a, $this->repo->findPendingJob());
+        $this->assertSame($b, $this->repo->findPendingJob(array(), array(), array('other_queue')));
+    }
+
     public function testFindStartableJob()
     {
         $this->assertNull($this->repo->findStartableJob());

--- a/Tests/Functional/RunCommandTest.php
+++ b/Tests/Functional/RunCommandTest.php
@@ -119,6 +119,63 @@ OUTPUT
     }
 
     /**
+     * @group queues
+     */
+    public function testSingleRestrictedQueue()
+    {
+        $a = new Job('jms-job-queue:successful-cmd');
+        $b = new Job('jms-job-queue:successful-cmd', array(), true, 'other_queue');
+        $c = new Job('jms-job-queue:successful-cmd', array(), true, 'yet_another_queue');
+        $this->em->persist($a);
+        $this->em->persist($b);
+        $this->em->persist($c);
+        $this->em->flush();
+
+        $this->doRun(array('--max-runtime' => 1, '--queue' => array('other_queue')));
+        $this->assertEquals(Job::STATE_PENDING, $a->getState());
+        $this->assertEquals(Job::STATE_FINISHED, $b->getState());
+        $this->assertEquals(Job::STATE_PENDING, $c->getState());
+    }
+
+    /**
+     * @group queues
+     */
+    public function testMultipleRestrictedQueues()
+    {
+        $a = new Job('jms-job-queue:successful-cmd');
+        $b = new Job('jms-job-queue:successful-cmd', array(), true, 'other_queue');
+        $c = new Job('jms-job-queue:successful-cmd', array(), true, 'yet_another_queue');
+        $this->em->persist($a);
+        $this->em->persist($b);
+        $this->em->persist($c);
+        $this->em->flush();
+
+        $this->doRun(array('--max-runtime' => 1, '--queue' => array('other_queue', 'yet_another_queue')));
+        $this->assertEquals(Job::STATE_PENDING, $a->getState());
+        $this->assertEquals(Job::STATE_FINISHED, $b->getState());
+        $this->assertEquals(Job::STATE_FINISHED, $c->getState());
+    }
+
+    /**
+     * @group queues
+     */
+    public function testNoRestrictedQueue()
+    {
+        $a = new Job('jms-job-queue:successful-cmd');
+        $b = new Job('jms-job-queue:successful-cmd', array(), true, 'other_queue');
+        $c = new Job('jms-job-queue:successful-cmd', array(), true, 'yet_another_queue');
+        $this->em->persist($a);
+        $this->em->persist($b);
+        $this->em->persist($c);
+        $this->em->flush();
+
+        $this->doRun(array('--max-runtime' => 1));
+        $this->assertEquals(Job::STATE_FINISHED, $a->getState());
+        $this->assertEquals(Job::STATE_FINISHED, $b->getState());
+        $this->assertEquals(Job::STATE_FINISHED, $c->getState());
+    }
+
+    /**
      * @group retry
      */
     public function testRetry()


### PR DESCRIPTION
This PR should solve https://github.com/schmittjoh/JMSJobQueueBundle/issues/88. The idea is to restrict the job runner to one or more queues, so multiple job runners can be run at the same time without trying to pick the same jobs.

When running the job runner command with the `--queue` option, it will pick jobs from the specified queue(s) only.

```shell
# will run as usual (pick jobs from any queue)
php console jms-job-queue:run

# will pick jobs from queue "q2" only
php console jms-job-queue:run --queue=q2

# will pick jobs from both queues "q2" and "q3"
php console jms-job-queue:run --queue=q2 --queue=q3
```