### PR TITLE
Manually specify name of workerName field, to prevent errors when working with underscore naming strategy

### DIFF
--- a/Entity/Job.php
+++ b/Entity/Job.php
@@ -110,7 +110,7 @@ class Job
     /** @ORM\Column(type = "datetime", name="checkedAt", nullable = true) */
     private $checkedAt;
 
-    /** @ORM\Column(type = "string", length = 50, nullable = true) */
+    /** @ORM\Column(type = "string", name="workerName", length = 50, nullable = true) */
     private $workerName;
 
     /** @ORM\Column(type = "datetime", name="executeAfter", nullable = true) */


### PR DESCRIPTION
Fixes an issue introduced in 922d005 that introduced the Job::$workerName field but didn't specify it's field name.