### PR TITLE
add started time in jobs details

### DIFF
--- a/Resources/views/Job/details.html.twig
+++ b/Resources/views/Job/details.html.twig
@@ -26,6 +26,12 @@
         <th>Created</th>
         <td>{{ macros.ago(job.createdAt) }}</td>
     </tr>
+    {% if job.startedAt %}
+    <tr>
+        <th>Started</th>
+        <td>{{ macros.ago(job.startedAt) }}</td>
+    </tr>
+    {% endif %}
     {% if job.closedAt %}
     <tr>
         <th>Runtime</th>


### PR DESCRIPTION
On the detail view of a job, add the start time.