### PR TITLE
Replaced deprecated Twig functions by Twig_SimpleFilter

### DIFF
--- a/Twig/JobQueueExtension.php
+++ b/Twig/JobQueueExtension.php
@@ -14,22 +14,22 @@ class JobQueueExtension extends \Twig_Extension
     public function getTests()
     {
         return array(
-            'jms_job_queue_linkable' => new \Twig_Test_Method($this, 'isLinkable'),
+            new \Twig_SimpleFilter('jms_job_queue_linkable', array($this, 'isLinkable'))
         );
     }
 
     public function getFunctions()
     {
         return array(
-            'jms_job_queue_path' => new \Twig_Function_Method($this, 'generatePath', array('is_safe' => array('html' => true))),
+            new \Twig_SimpleFilter('jms_job_queue_path', array($this, 'generatePath'), array('is_safe' => array('html' => true)))
         );
     }
 
     public function getFilters()
     {
         return array(
-            'jms_job_queue_linkname' => new \Twig_Filter_Method($this, 'getLinkname'),
-            'jms_job_queue_args' => new \Twig_Filter_Method($this, 'formatArgs'),
+            new \Twig_SimpleFilter('jms_job_queue_linkname', array($this, 'getLinkname')),
+            new \Twig_SimpleFilter('jms_job_queue_args', array($this, 'formatArgs'))
         );
     }
 


### PR DESCRIPTION
This commit fixes #112 