### PR TITLE
don’t connect to mysql on boot

### DIFF
--- a/DependencyInjection/JMSJobQueueExtension.php
+++ b/DependencyInjection/JMSJobQueueExtension.php
@@ -18,8 +18,10 @@
 
 namespace JMS\JobQueueBundle\DependencyInjection;
 
+use JMS\JobQueueBundle\Entity\Type\SafeObjectType;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\DependencyInjection\Loader;
 
@@ -28,7 +30,7 @@ use Symfony\Component\DependencyInjection\Loader;
  *
  * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html}
  */
-class JMSJobQueueExtension extends Extension
+class JMSJobQueueExtension extends Extension implements PrependExtensionInterface
 {
     /**
      * {@inheritDoc}
@@ -48,5 +50,27 @@ class JMSJobQueueExtension extends Extension
 
         $container->setParameter('jms_job_queue.queue_options_defaults', $config['queue_options_defaults']);
         $container->setParameter('jms_job_queue.queue_options', $config['queue_options']);
+    }
+
+    /**
+     * Allow an extension to prepend the extension configurations.
+     *
+     * @param ContainerBuilder $container
+     */
+    public function prepend(ContainerBuilder $container)
+    {
+        $container->prependExtensionConfig(
+            'doctrine',
+            [
+                'dbal' => [
+                    'types' => [
+                        'jms_job_safe_object' => [
+                            'class' => SafeObjectType::class,
+                            'commented' => true,
+                        ],
+                    ],
+                ],
+            ]
+        );
     }
 }

--- a/JMSJobQueueBundle.php
+++ b/JMSJobQueueBundle.php
@@ -18,12 +18,9 @@
 
 namespace JMS\JobQueueBundle;
 
-use Doctrine\Common\Persistence\ManagerRegistry;
-use Doctrine\DBAL\Connection;
 use JMS\JobQueueBundle\DependencyInjection\CompilerPass\LinkGeneratorsPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
-use Doctrine\DBAL\Types\Type;
 
 class JMSJobQueueBundle extends Bundle
 {
@@ -32,18 +29,4 @@ class JMSJobQueueBundle extends Bundle
         $container->addCompilerPass(new LinkGeneratorsPass());
     }
 
-    public function boot()
-    {
-        if ( ! Type::hasType('jms_job_safe_object')) {
-            Type::addType('jms_job_safe_object', 'JMS\JobQueueBundle\Entity\Type\SafeObjectType');
-        }
-
-        /** @var ManagerRegistry $registry*/
-        $registry = $this->container->get('doctrine');
-        foreach ($registry->getConnections() as $con) {
-            if ($con instanceof Connection) {
-                $con->getDatabasePlatform()->markDoctrineTypeCommented('jms_job_safe_object');
-            }
-        }
-    }
 }


### PR DESCRIPTION
Fixes #81, different implementation of #87 

Removes the `boot` method and appends a doctrine configuration defining the custom type instead.