### PR TITLE
return an array of the right kind of objects for Twig Extension.

### DIFF
--- a/Twig/JobQueueExtension.php
+++ b/Twig/JobQueueExtension.php
@@ -14,14 +14,14 @@ class JobQueueExtension extends \Twig_Extension
     public function getTests()
     {
         return array(
-            new \Twig_SimpleFilter('jms_job_queue_linkable', array($this, 'isLinkable'))
+            new \Twig_SimpleTest('jms_job_queue_linkable', array($this, 'isLinkable'))
         );
     }
 
     public function getFunctions()
     {
         return array(
-            new \Twig_SimpleFilter('jms_job_queue_path', array($this, 'generatePath'), array('is_safe' => array('html' => true)))
+            new \Twig_SimpleFunction('jms_job_queue_path', array($this, 'generatePath'), array('is_safe' => array('html' => true)))
         );
     }
 


### PR DESCRIPTION
This fixes the bugs introduced in https://github.com/schmittjoh/JMSJobQueueBundle/commit/4f67b62beac083965a5f77bce4929e2a9e66e4dd