### PR TITLE
Change \Twig_SimpleFilter to \Twig_Simple[Test|Function]

### DIFF
--- a/Twig/JobQueueExtension.php
+++ b/Twig/JobQueueExtension.php
@@ -14,14 +14,14 @@ class JobQueueExtension extends \Twig_Extension
     public function getTests()
     {
         return array(
-            new \Twig_SimpleFilter('jms_job_queue_linkable', array($this, 'isLinkable'))
+            new \Twig_SimpleTest('jms_job_queue_linkable', array($this, 'isLinkable'))
         );
     }
 
     public function getFunctions()
     {
         return array(
-            new \Twig_SimpleFilter('jms_job_queue_path', array($this, 'generatePath'), array('is_safe' => array('html' => true)))
+            new \Twig_SimpleFunction('jms_job_queue_path', array($this, 'generatePath'), array('is_safe' => array('html' => true)))
         );
     }
 


### PR DESCRIPTION
The use of `\Twig_SimpleFilter` in the tests or function array triggers deprecation warnings.

```
DEPRECATED - Using an instance of "Twig_SimpleFilter" for function "0" is deprecated.
             Use Twig_SimpleFunction instead.
DEPRECATED - Using an instance of "Twig_SimpleFilter" for test "0" is deprecated.
             Use Twig_SimpleTest instead.
```