### PR TITLE
Detect if the console binary is in new symfony 3 structure folder

### DIFF
--- a/Command/RunCommand.php
+++ b/Command/RunCommand.php
@@ -428,9 +428,15 @@ class RunCommand extends \Symfony\Bundle\FrameworkBundle\Command\ContainerAwareC
             $pb->add('exec');
         }
 
+        $consolePath = $this->getContainer()->getParameter('kernel.root_dir').'/console';
+        // Detect if console binary is in new symfony 3 structure folder
+        if(file_exists($this->getContainer()->getParameter('kernel.root_dir').'/../bin/console')){
+            $consolePath = realpath($this->getContainer()->getParameter('kernel.root_dir').'/../bin/console');
+        }
+
         $pb
             ->add('php')
-            ->add($this->getContainer()->getParameter('kernel.root_dir').'/console')
+            ->add($consolePath)
             ->add('--env='.$this->env)
         ;
 


### PR DESCRIPTION
Hey,

I am patching RunCommand file to detect if the console binary is in new symfony 3 structure folder. Users who has new structure folder would get error as console file wouldn´t be found. Is it okay to go?