### PR TITLE
Quote reserved word

### DIFF
--- a/Entity/Job.php
+++ b/Entity/Job.php
@@ -134,7 +134,7 @@ class Job
      */
     private $dependencies;
 
-    /** @ORM\Column(type = "text", nullable = true) */
+    /** @ORM\Column(type = "text", name="`output`", nullable = true) */
     private $output;
 
     /** @ORM\Column(type = "text", name="errorOutput", nullable = true) */


### PR DESCRIPTION
In some doctrine platforms (for example ASE and properly older SQLServer versions) output is a reserved word. For this reason we should tell doctrine to quote it. Using backticks here infront of the name is the doctrine standard portable way to enable quoting for columns.