### PR TITLE
Fix for getAvailableJobsForQueueCount in JobRepository

### DIFF
--- a/Entity/Repository/JobRepository.php
+++ b/Entity/Repository/JobRepository.php
@@ -436,14 +436,12 @@ class JobRepository extends EntityRepository
         return $newQueueArray;
     }
 
-
     public function getAvailableJobsForQueueCount($jobQueue)
     {
         $result = $this->_em->createQuery("SELECT j.queue FROM JMSJobQueueBundle:Job j WHERE j.state IN (:availableStates) AND j.queue = :queue")
             ->setParameter('availableStates', array(Job::STATE_RUNNING, Job::STATE_NEW, Job::STATE_PENDING))
             ->setParameter('queue', $jobQueue)
-            ->setMaxResults(1)
-            ->getOneOrNullResult();
+            ->getResult();
 
         return count($result);
     }


### PR DESCRIPTION
The count only returned 0 or 1, where the name suggest returning the real count of available jobs. In this pull request it does return the correct amount.
