### PR TITLE
Constraint violations in jms_job_statistics

### DIFF
--- a/Entity/Listener/StatisticsListener.php
+++ b/Entity/Listener/StatisticsListener.php
@@ -16,10 +16,12 @@ class StatisticsListener
         }
 
         $table = $schema->createTable('jms_job_statistics');
+        $table->addColumn('id', 'bigint', array('nullable' => false, 'unsigned' => true, 'autoincrement' => true));
         $table->addColumn('job_id', 'bigint', array('nullable' => false, 'unsigned' => true));
         $table->addColumn('characteristic', 'string', array('length' => 30, 'nullable' => false));
         $table->addColumn('createdAt', 'datetime', array('nullable' => false));
         $table->addColumn('charValue', 'float', array('nullable' => false));
-        $table->setPrimaryKey(array('job_id', 'characteristic', 'createdAt'));
+        $table->setPrimaryKey(array('id'));
+        $table->addIndex(array('job_id'));
     }
 }


### PR DESCRIPTION
During RunCommand execution i often raise such an exception:

```
Job 226:   [Doctrine\DBAL\DBALException]                                                                                                                                                                                                     
Job 226:   An exception occurred while executing 'INSERT INTO jms_job_statistics (job_id, characteristic, createdAt, charValue) VALUES (:jobId, :name, :createdAt, :value)' with params ["226", "2016-09-08 14:43:02", "memory", 41265120]:  
Job 226:   SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '226-memory-2016-09-08 14:43:02' for key 'PRIMARY' 
```

The reason is that `jms_job_statistics` table has complex primary key consists of `job_id`, `characteristic`, `createdAt` columns. I am facing constraint violations for this key when there are several attempts to write job statistic during the same second (in this case all the values of key columns have the same value).

Theoretically we can try to reduce frequency of [Application::onTick](https://github.com/schmittjoh/JMSJobQueueBundle/blob/1.3.0/Console/Application.php#L56) calls by increasing the ticks count in [Application's declare statement](https://github.com/schmittjoh/JMSJobQueueBundle/blob/1.3.0/Console/Application.php#L5), but this approach is not so reliable. 

What if we change `jms_job_statistics` by creating autoincrement simple primary key and adding index for `job_id` column (for effective fetching statistics info for the job)? 