### PR TITLE
Improve Job cloning on creation of a Retry

### DIFF
--- a/Entity/Repository/JobRepository.php
+++ b/Entity/Repository/JobRepository.php
@@ -327,7 +327,7 @@ class JobRepository extends EntityRepository
 
                 // The original job has failed, and we are allowed to retry it.
                 if ($job->isRetryAllowed()) {
-                    $retryJob = new Job($job->getCommand(), $job->getArgs());
+                    $retryJob = new Job($job->getCommand(), $job->getArgs(), true, $job->getQueue(), $job->getPriority());
                     $retryJob->setMaxRuntime($job->getMaxRuntime());
 
                     if ($this->retryScheduler === null) {


### PR DESCRIPTION
When a retry is scheduled for a Job, not all parameters are copied from the original Job. This patch sets the status, queue and priority, mirroring the original Job.