### PR TITLE
Configure path to php cli #154

### DIFF
--- a/Command/RunCommand.php
+++ b/Command/RunCommand.php
@@ -433,7 +433,7 @@ class RunCommand extends \Symfony\Bundle\FrameworkBundle\Command\ContainerAwareC
         }
 
         $pb
-            ->add('php')
+            ->add($this->getContainer()->getParameter('jms_job_queue.php_cli_path'))
             ->add($this->consoleFile)
             ->add('--env='.$this->env)
         ;

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -39,6 +39,10 @@ class Configuration implements ConfigurationInterface
 
         $rootNode
             ->children()
+                ->scalarNode('php_cli_path')->defaultValue('php')->end();
+
+        $rootNode
+            ->children()
                 ->booleanNode('statistics')->defaultTrue()->end();
 
         $defaultOptionsNode = $rootNode

--- a/DependencyInjection/JMSJobQueueExtension.php
+++ b/DependencyInjection/JMSJobQueueExtension.php
@@ -50,6 +50,7 @@ class JMSJobQueueExtension extends Extension implements PrependExtensionInterfac
 
         $container->setParameter('jms_job_queue.queue_options_defaults', $config['queue_options_defaults']);
         $container->setParameter('jms_job_queue.queue_options', $config['queue_options']);
+        $container->setParameter('jms_job_queue.php_cli_path', $config['php_cli_path']);
     }
 
     public function prepend(ContainerBuilder $container)

--- a/Resources/doc/installation.rst
+++ b/Resources/doc/installation.rst
@@ -52,6 +52,13 @@ Finally, have your ``app/console`` use JMSJobQueueBundle's ``Application``:
     // use Symfony\Bundle\FrameworkBundle\Console\Application;
     use JMS\JobQueueBundle\Console\Application;
 
+If there is a need for you to explicitly set path to php binary which has to
+be used when executing your jobs, you can provide path within configuration:
+
+.. code-block :: yaml
+
+    jms_security_extra:
+        php_cli_path: /path/to/your/binary/php
 
 Enabling the Webinterface
 =========================

--- a/Resources/doc/installation.rst
+++ b/Resources/doc/installation.rst
@@ -57,7 +57,7 @@ be used when executing your jobs, you can provide path within configuration:
 
 .. code-block :: yaml
 
-    jms_security_extra:
+    jms_job_queue:
         php_cli_path: /path/to/your/binary/php
 
 Enabling the Webinterface


### PR DESCRIPTION
Fix for #154

No BC break. 

Useful for shared hosts with multiple PHP installations.