### PR TITLE
FQCN for class constant

### DIFF
--- a/Entity/Job.php
+++ b/Entity/Job.php
@@ -95,7 +95,7 @@ class Job
     /** @ORM\Column(type = "string", length = 15) */
     private $state;
 
-    /** @ORM\Column(type = "string", length = Job::MAX_QUEUE_LENGTH) */
+    /** @ORM\Column(type = "string", length = JMS\JobQueueBundle\Entity\Job::MAX_QUEUE_LENGTH) */
     private $queue;
 
     /** @ORM\Column(type = "smallint") */


### PR DESCRIPTION
This PR adds a FQCN to the Job class constant in the queue annotation of the Job entity.

Since Symfony 3.2 there is a AnnotationCacheWarmer which uses a CachedReader from doctrine/annotations. This reader seems to have problems with a class constant that does not have a FQCN.

See:
https://github.com/doctrine/annotations/issues/115
and
https://github.com/schmittjoh/JMSJobQueueBundle/issues/158