### PR TITLE
Change getEm() and getRepo() to protected

### DIFF
--- a/Controller/JobController.php
+++ b/Controller/JobController.php
@@ -149,13 +149,13 @@ class JobController
     }
 
     /** @return \Doctrine\ORM\EntityManager */
-    private function getEm()
+    protected function getEm()
     {
         return $this->registry->getManagerForClass('JMSJobQueueBundle:Job');
     }
 
     /** @return \JMS\JobQueueBundle\Entity\Repository\JobRepository */
-    private function getRepo()
+    protected function getRepo()
     {
         return $this->getEm()->getRepository('JMSJobQueueBundle:Job');
     }


### PR DESCRIPTION
Fix allows to override any function form JobController as it wasn't possible due to null $registry on parent controller.