### PR TITLE
Create Process with command line instead of ProcessBuilder

### DIFF
--- a/Command/RunCommand.php
+++ b/Command/RunCommand.php
@@ -363,7 +363,8 @@ class RunCommand extends \Symfony\Bundle\FrameworkBundle\Command\ContainerAwareC
         foreach ($job->getArgs() as $arg) {
             $pb->add($arg);
         }
-        $proc = $pb->getProcess();
+        
+        $proc = new Process($pb->getProcess()->getCommandLine());
         $proc->start();
         $this->output->writeln(sprintf('Started %s.', $job));
 
@@ -410,7 +411,7 @@ class RunCommand extends \Symfony\Bundle\FrameworkBundle\Command\ContainerAwareC
             ;
 
             // We use a separate process to clean up.
-            $proc = $pb->getProcess();
+            $proc = new Process($pb->getProcess()->getCommandLine());
             if (0 !== $proc->run()) {
                 $ex = new ProcessFailedException($proc);
 


### PR DESCRIPTION
Fixes https://github.com/schmittjoh/JMSJobQueueBundle/issues/171
Similar to https://github.com/schmittjoh/JMSJobQueueBundle/pull/175 but only 2 lines of change
Tested on Symfony 2.8 (phpunit) and Symfony 3.3