### PR TITLE
Changed ProcessBuilder to Process in RunCommand (Symfony 3.4 Compatibility)

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -13,7 +13,7 @@
 
     <services>
         <service id="jms_job_queue.retry_scheduler" class="%jms_job_queue.retry_scheduler.class%" />
-        <service id="jms_job_queue.scheduler_registry" class="%jms_job_queue.scheduler_registry.class%" />
+        <service id="jms_job_queue.scheduler_registry" public="true" class="%jms_job_queue.scheduler_registry.class%" />
 
         <service id="jms_job_queue.entity.many_to_any_listener" class="%jms_job_queue.entity.many_to_any_listener.class%">
             <argument type="service" id="doctrine" />


### PR DESCRIPTION
Because there is a deprectation warning when you use the ProcessBuilder class in Symfony 3.4 (Because it gets removed in Symfony 4.0), I changed the code segments in this specific Command to call the Process class directly. The behaviour is still the same.