### PR TITLE
Add a «Progress» field for jobs

### DIFF
--- a/Command/RunCommand.php
+++ b/Command/RunCommand.php
@@ -296,9 +296,6 @@ class RunCommand extends \Symfony\Bundle\FrameworkBundle\Command\ContainerAwareC
                 $data['process']->stop(5);
 
                 $this->output->writeln($data['job'].' terminated; maximum runtime exceeded.');
-                $data['job']->setProgress(1);
-                $em = $this->getEntityManager();
-                $em->persist($data['job']);
                 $em->flush();
                 $this->getRepository()->closeJob($data['job'], Job::STATE_TERMINATED);
                 unset($this->runningJobs[$i]);
@@ -324,6 +321,7 @@ class RunCommand extends \Symfony\Bundle\FrameworkBundle\Command\ContainerAwareC
             // get access to the stack trace. This might be useful for listeners.
             $this->getEntityManager()->refresh($data['job']);
 
+            $data['job']->setProgress(1);
             $data['job']->setExitCode($data['process']->getExitCode());
             $data['job']->setOutput($data['process']->getOutput());
             $data['job']->setErrorOutput($data['process']->getErrorOutput());

--- a/Command/RunCommand.php
+++ b/Command/RunCommand.php
@@ -296,7 +296,6 @@ class RunCommand extends \Symfony\Bundle\FrameworkBundle\Command\ContainerAwareC
                 $data['process']->stop(5);
 
                 $this->output->writeln($data['job'].' terminated; maximum runtime exceeded.');
-                $em->flush();
                 $this->getRepository()->closeJob($data['job'], Job::STATE_TERMINATED);
                 unset($this->runningJobs[$i]);
 

--- a/Command/RunCommand.php
+++ b/Command/RunCommand.php
@@ -296,6 +296,10 @@ class RunCommand extends \Symfony\Bundle\FrameworkBundle\Command\ContainerAwareC
                 $data['process']->stop(5);
 
                 $this->output->writeln($data['job'].' terminated; maximum runtime exceeded.');
+                $data['job']->setProgress(1);
+                $em = $this->getEntityManager();
+                $em->persist($data['job']);
+                $em->flush();
                 $this->getRepository()->closeJob($data['job'], Job::STATE_TERMINATED);
                 unset($this->runningJobs[$i]);
 

--- a/Entity/Job.php
+++ b/Entity/Job.php
@@ -101,6 +101,9 @@ class Job
     /** @ORM\Column(type = "smallint") */
     private $priority = 0;
 
+    /** @ORM\Column(type = "float") */
+    private $progress = 0.0;
+
     /** @ORM\Column(type = "datetime", name="createdAt") */
     private $createdAt;
 
@@ -227,6 +230,7 @@ class Job
     public function __clone()
     {
         $this->state = self::STATE_PENDING;
+        $this->progress = 0.0;
         $this->createdAt = new \DateTime();
         $this->startedAt = null;
         $this->checkedAt = null;
@@ -335,6 +339,16 @@ class Job
         }
 
         $this->state = $newState;
+    }
+
+    public function getProgress()
+    {
+        return $this->progress;
+    }
+
+    public function setProgress($progress)
+    {
+        $this->progress = $progress;
     }
 
     public function getCreatedAt()


### PR DESCRIPTION
When running long jobs, it's cool to have an idea of the command's progress.

So, with a new `progress` field in Job table, we're able to set progression in the run command by using `jms-job-id` argument.

For example, a command could look like this:
```
protected function execute(InputInterface $input, OutputInterface $output)
{
       // ……
       // Do stuff
       // ……
        $argument = $input->getOption('jms-job-id');
        $job = $this->entityManager->getRepository(Job::class)->find($argument);
        $job->setProgress(0.3);
        $this->entityManager->flush($job);
        // ……
        // Do other stuff
        // ……
        $job->setProgress(0.6);
        $this->entityManager->flush($job);

        // Etc
        // ……
}
```

Of course, when a job is finished, its progress is automatically set to 1.
If job fails or is terminated without success, its last progress is kept.