### PR TITLE
fix(JobSchedulersPass): Fix issue with ServiceNotFound Exception

### DIFF
--- a/DependencyInjection/CompilerPass/JobSchedulersPass.php
+++ b/DependencyInjection/CompilerPass/JobSchedulersPass.php
@@ -21,7 +21,7 @@ class JobSchedulersPass implements CompilerPassInterface
             }
         }
 
-        $container->getDefinition('jms_job_queue.scheduler_registry')
+        $container->findDefinition('jms_job_queue.scheduler_registry')
             ->addArgument($schedulers);
     }
 }


### PR DESCRIPTION
Change `getDefinition` to `findDefinition`