### PR TITLE
[WIP] Compatibility with Symfony 3.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
     ],
     "require": {
         "php": "^7.1",
-        "symfony/framework-bundle": "^4.0",
-        "symfony/debug": "^4.0",
+        "symfony/framework-bundle": "^3.4|^4.0",
+        "symfony/debug": "^3.4|^4.0",
         "doctrine/common": "^2.3"
     },
     "require-dev": {


### PR DESCRIPTION
Branch `symfony4` removes the dependency on `di-extra-bundle`. As many projects are still in the progress of upgrading `3.4` to `4.0`, still supporting `3.4` for now would be welcome. After comparing `symfony4` to `master` it seems that no Symfony 4 specific features are used so far.

## References

https://github.com/symfony/symfony/issues/27053

https://github.com/schmittjoh/JMSDiExtraBundle/issues/282
