### PR TITLE
add missing _display_code_snippet variable

### DIFF
--- a/Resources/views/Job/details.html.twig
+++ b/Resources/views/Job/details.html.twig
@@ -129,9 +129,12 @@
         </h4>
         <a id="traces_link_{{ position }}"></a>
         <ol class="traces list_ex" id="traces_{{ position }}" style="display: none;">
+            {% set _is_first_user_code = true %}
             {% for i, trace in ex.trace %}
+                {% set _display_code_snippet = _is_first_user_code and ('/vendor/' not in trace.file) and ('/var/cache/' not in trace.file) and (trace.file is not empty) %}
+                {% if _display_code_snippet %}{% set _is_first_user_code = false %}{% endif %}
                 <li>
-                    {% include 'TwigBundle:Exception:trace.html.twig' with { 'prefix': position, 'i': i, 'trace': trace } only %}
+                    {% include 'TwigBundle:Exception:trace.html.twig' with { 'prefix': position, 'i': i, 'trace': trace, _display_code_snippet: _display_code_snippet } only %}
                 </li>
             {% endfor %}
         </ol>


### PR DESCRIPTION
This will fix an issue with the required '_display_code_snippet' in symfony twigbundle

TwigBundle/Resources/views/Exception/trace.html.twig
>             Exception
>             Variable "_display_code_snippet" does not exists.