### PR TITLE
Fix deprecated assert() usage in Job addRelatedEntity method

### DIFF
--- a/Entity/Job.php
+++ b/Entity/Job.php
@@ -390,7 +390,7 @@ class Job
 
     public function addRelatedEntity($entity)
     {
-        assert('is_object($entity)');
+        assert(true === is_object($entity));
 
         if ($this->relatedEntities->contains($entity)) {
             return;


### PR DESCRIPTION
Assert using a string parameter to be evaluated is deprecated as of PHP 7.2.