### PR TITLE
Fix A tree builder without a root node is deprecated since Symfony 4.…

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -34,8 +34,12 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('jms_job_queue');
+        $treeBuilder = new TreeBuilder('jms_job_queue');
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            $rootNode = $treeBuilder->root('jms_job_queue');
+        }
 
         $rootNode
             ->children()


### PR DESCRIPTION

Fix A tree builder without a root node is deprecated since Symfony 4.2 and will not be supported anymore in 5.0.
--


