### PR TITLE
removed deprecations in symfony 3.4:

### DIFF
--- a/Controller/JobController.php
+++ b/Controller/JobController.php
@@ -7,7 +7,7 @@ use Doctrine\ORM\EntityManager;
 use JMS\JobQueueBundle\Entity\Job;
 use JMS\JobQueueBundle\Entity\Repository\JobManager;
 use JMS\JobQueueBundle\View\JobFilter;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;

--- a/DependencyInjection/JMSJobQueueExtension.php
+++ b/DependencyInjection/JMSJobQueueExtension.php
@@ -66,8 +66,7 @@ class JMSJobQueueExtension extends Extension implements PrependExtensionInterfac
             'dbal' => array(
                 'types' => array(
                     'jms_job_safe_object' => array(
-                        'class' => SafeObjectType::class,
-                        'commented' => true,
+                        'class' => SafeObjectType::class
                     )
                 )
             )


### PR DESCRIPTION
DependencyInjection/JMSJobQueueExtension.php:
The type "jms_job_safe_object" was explicitly marked as commented in its configuration. This is no longer necessary and will be removed in DoctrineBundle 2.0. Please remove the "commented" attribute from the type configuration.

Controller/JobController.php:
The "Sensio\Bundle\FrameworkExtraBundle\Configuration\Route" annotation is deprecated since version 5.2. Use "Symfony\Component\Routing\Annotation\Route" instead.