### PR TITLE
Do not break when there are still running jobs.

### DIFF
--- a/Command/RunCommand.php
+++ b/Command/RunCommand.php
@@ -173,15 +173,20 @@ class RunCommand extends Command
                 pcntl_signal_dispatch();
             }
 
-            if ($this->shouldShutdown || time() - $startTime > $maxRuntime) {
+            $this->checkRunningJobs();
+
+            $shouldShutdown = $this->shouldShutdown || time() - $startTime > $maxRuntime;
+
+            if($shouldShutdown === true && empty($this->runningJobs)){
                 break;
             }
 
-            $this->checkRunningJobs();
-            $this->startJobs($workerName, $idleTime, $maxJobs, $restrictedQueues, $queueOptionsDefaults, $queueOptions);
+            if($shouldShutdown === false){
+                $this->startJobs($workerName, $idleTime, $maxJobs, $restrictedQueues, $queueOptionsDefaults, $queueOptions);
+            }
 
             $waitTimeInMs = random_int(500, 1000);
-            usleep($waitTimeInMs * 1E3);
+            usleep((int) ($waitTimeInMs * 1E3));
         }
 
         if ($this->verbose) {


### PR DESCRIPTION
Currently the `RunCommand::runJobs` terminates when it receives a `SIGTERM` or the `$maxRuntime` is expired. When this happens the running jobs are also terminated and remain as `running`.

This change makes sure that `runJobs` waits until all running jobs are finished and doesn't start any new jobs when it is instructed to shutdown.