### PR TITLE
Add support for Symfony v4.4

### DIFF
--- a/Entity/Listener/ManyToAnyListener.php
+++ b/Entity/Listener/ManyToAnyListener.php
@@ -19,7 +19,7 @@ class ManyToAnyListener
     private $registry;
     private $ref;
 
-    public function __construct(\Symfony\Bridge\Doctrine\RegistryInterface $registry)
+    public function __construct(\Doctrine\Common\Persistence\ManagerRegistry $registry)
     {
         $this->registry = $registry;
         $this->ref = new \ReflectionProperty('JMS\JobQueueBundle\Entity\Job', 'relatedEntities');

--- a/Entity/Listener/PersistentRelatedEntitiesCollection.php
+++ b/Entity/Listener/PersistentRelatedEntitiesCollection.php
@@ -9,8 +9,8 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\Common\Collections\Expr\ClosureExpressionVisitor;
 use Doctrine\Common\Collections\Selectable;
+use Doctrine\Common\Persistence\ManagerRegistry;
 use JMS\JobQueueBundle\Entity\Job;
-use Symfony\Bridge\Doctrine\RegistryInterface;
 
 /**
  * Collection for persistent related entities.
@@ -25,7 +25,7 @@ class PersistentRelatedEntitiesCollection implements Collection, Selectable
     private $job;
     private $entities;
 
-    public function __construct(RegistryInterface $registry, Job $job)
+    public function __construct(ManagerRegistry $registry, Job $job)
     {
         $this->registry = $registry;
         $this->job = $job;


### PR DESCRIPTION
This fixes compatibility with Symfony v4.4 (changing references of `Symfony\Bridge\Doctrine\RegistryInterface`, which has been removed, to `Doctrine\Common\Persistence\ManagerRegistry`).

See https://github.com/symfony/symfony/issues/32394