### PR TITLE
Fix NonUniqueResultException thrown by JobManager#findJobForRelatedEntity if multiple results are found

### DIFF
--- a/Entity/Repository/JobManager.php
+++ b/Entity/Repository/JobManager.php
@@ -155,7 +155,7 @@ class JobManager
         $rsm = new ResultSetMappingBuilder($this->getJobManager());
         $rsm->addRootEntityFromClassMetadata('JMSJobQueueBundle:Job', 'j');
 
-        $sql = "SELECT j.* FROM jms_jobs j INNER JOIN jms_job_related_entities r ON r.job_id = j.id WHERE r.related_class = :relClass AND r.related_id = :relId AND j.command = :command";
+        $sql = "SELECT j.* FROM jms_jobs j INNER JOIN jms_job_related_entities r ON r.job_id = j.id WHERE r.related_class = :relClass AND r.related_id = :relId AND j.command = :command LIMIT 1";
         $params = new ArrayCollection();
         $params->add(new Parameter('command', $command));
         $params->add(new Parameter('relClass', $relClass));


### PR DESCRIPTION
A `Doctrine\ORM\NonUniqueResultException` is thrown by `JobManager#findJobForRelatedEntity` if there are multiple instances of the same command that share the same related entity.

Looking at some of the other methods in this class that explicitly restrict the SQL result set to 1 row if only one entity is expected, I thought adding a limit to this method made sense.